### PR TITLE
Add basic support for PIN number authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     </div>
     <div id="controls" style="display: none;">
       <button onclick="collar.disconnect()">Disconnect</button><br/><br/>
+      <button onclick="collar.authorize(1,2,3,4)">Authorize</button><br/><br/>
       <button onclick="collar.runTone()">Tone</button><br/><br/>
       <button onclick="collar.runVibrate()">Vibrate</button><br/><br/>
       <b>Shock Level:</b><br/>

--- a/trainer.js
+++ b/trainer.js
@@ -3,10 +3,13 @@
 const COLLAR_BT_NAME = "PetSafe Smart Dog Trainer";
 const COLLAR_COMMAND_SERVICE = "0bd51666-e7cb-469b-8e4d-2742f1ba77cc";
 const COLLAR_COMMAND_CHARACTERISTIC = "e7add780-b042-4876-aae1-112855353cc1";
+const COLLAR_AUTH_CHARACTERISTIC = "0e7ad781-b043-4877-aae2-112855353cc2";
 const COLLAR_TONE_COMMAND = [0x55, 0x36, 0x31, 0x31, 0x31, 0x30];
 const COLLAR_VIBRATE_COMMAND = [0x55, 0x36, 0x31, 0x33, 0x33, 0x30];
 // Last byte is command strength (0-15) + 0x48. We set it to 0 here.
 const COLLAR_STATIC_COMMAND = [0x55, 0x36, 0x31, 0x32, 0x33, 0x30];
+// Last four bytes are the ASCII values of the PIN digits
+const COLLAR_AUTH_COMMAND = [0x55, 0x37, 0x37, 0x30, 0x30, 0x30, 0x30];
 
 class PetsafeSmartDogTrainingCollar {
   constructor() {
@@ -26,13 +29,23 @@ class PetsafeSmartDogTrainingCollar {
     let server = await this.device.gatt.connect();
     this.service = await server.getPrimaryService(COLLAR_COMMAND_SERVICE);
     this.tx = await this.service.getCharacteristic(COLLAR_COMMAND_CHARACTERISTIC);
+    this.auth = await this.service.getCharacteristic(COLLAR_AUTH_CHARACTERISTIC)
     console.log("Connected");
   }
 
   async disconnect() {
     await this.device.gatt.disconnect();
   }
-
+  async authorize(d1,d2,d3,d4){
+    console.log("Authenticating with ",d1,d2,d3,d4)
+    let r = new Uint8Array(COLLAR_AUTH_COMMAND);
+    r[3] += d1;
+    r[4] += d2;
+    r[5] += d3;
+    r[6] += d4;
+    console.log(r)
+    this.auth.writeValue(r)
+  }
   async runTone() {
     console.log("Running tone");
     this.tx.writeValue(new Uint8Array(COLLAR_TONE_COMMAND));


### PR DESCRIPTION
This is a simple proof of concept for PIN number authentication. It's not checking error replies yet (I'm not even sure how to) or supporting changing the pin, and it's currently hardcoded to 1234 in the HTML.
But it has the basic implementation for using PIN number-secured collars.

It seems how the collar works is that after a pin number reset, it's open to all commands, but once a pin number has been set (from the app), it ignores all commands until you issue the auth command.

For documentation, to issue a reset: 
1. Turn it off, if it's on. (Hold down the power button until it shows red and then beeps after a few seconds)
2. Turn it on by holing down the button for a few seconds. It'll show green, then beep low-high after a few seconds. Release the button
3. Wait for the light to blink after about 5 seconds. When that happens, hold it down and wait.
4. After a few seconds, it'll do the high-low beep of powering off. Continue holding.
5. about 10 seconds, it'll beep four times. The pin number is now reset (and the collar is turned off)